### PR TITLE
Feature/78 diaryhandling

### DIFF
--- a/mongeul/src/actions/write-diary.ts
+++ b/mongeul/src/actions/write-diary.ts
@@ -269,6 +269,7 @@ export async function getPictureLines(diaryId: number): Promise<{
   pictureLines: PictureLine[];
 }> {
   try {
+    console.log("저장된 그림 서버액션에서 불러오기");
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
     const response = await fetch(
@@ -279,7 +280,7 @@ export async function getPictureLines(diaryId: number): Promise<{
           "Content-Type": "application/json",
           Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
         },
-        cache: "force-cache",
+        cache: "no-store",
       }
     );
 
@@ -287,7 +288,7 @@ export async function getPictureLines(diaryId: number): Promise<{
       const errorMessage = await response.text();
       throw new Error(`그림 일기 Lines 조회 실패: ${errorMessage}`);
     }
-
+    console.log("저장된 그림 상태", response);
     const result: PictureLineResponse = await response.json();
     return result.data;
   } catch (error) {

--- a/mongeul/src/app/(is-login)/write-diary/page.tsx
+++ b/mongeul/src/app/(is-login)/write-diary/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-import { useSearchParams } from "next/navigation";
 import WriteForm from "@/components/write-diary/templates/WriteForm";
 import DraftAlertModal from "@/components/write-diary/molecules/DraftAlertModal";
 

--- a/mongeul/src/components/feed/molecules/FeedEmojiGroup.tsx
+++ b/mongeul/src/components/feed/molecules/FeedEmojiGroup.tsx
@@ -6,17 +6,17 @@ export default function FeedEmojiGroup() {
   const emojis = useSelector((state: RootState) => state.feed.feedDetailEmojis);
 
   return (
-    <div className="flex flex-row gap-2">
-      {emojis.map((emoji) => {
-        return (
+    <div className="w-full overflow-x-auto scrollbar-hide">
+      <div className="flex flex-row gap-2 min-w-max">
+        {emojis.map((emoji) => (
           <FeedEmojiCountButton
             key={emoji.emojiType}
             emoji={emoji.emojiType}
             count={emoji.count}
             isSelected={emoji.isSelected}
           />
-        );
-      })}
+        ))}
+      </div>
     </div>
   );
 }

--- a/mongeul/src/components/feed/templates/FeedDetailTemplates.tsx
+++ b/mongeul/src/components/feed/templates/FeedDetailTemplates.tsx
@@ -52,7 +52,7 @@ export default function FeedDetailTemplates() {
     <div className="w-full flex flex-col justify-center items-center">
       <div className="w-full">
         <DiaryDetailContainer diary={feed} />
-        <div className="flex flex-row flex-wrap items-center gap-2 h-auto py-4 px-2">
+        <div className="flex flex-row items-center gap-2 h-auto py-4 px-2">
           <FeedCommentButton />
           <FeedLikeButton />
           <FeedEmojiGroup />

--- a/mongeul/src/components/navbar/atoms/LinkPersonalDiaryButton.tsx
+++ b/mongeul/src/components/navbar/atoms/LinkPersonalDiaryButton.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { ReactElement } from "react";
 import { fetchIsWrite } from "@/lib/api/write-diary";
 

--- a/mongeul/src/components/navbar/atoms/LinkWriteButton.tsx
+++ b/mongeul/src/components/navbar/atoms/LinkWriteButton.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import LinkPersonalDiaryButton from "./LinkPersonalDiaryButton";
 import LinkSharedDiaryButton from "./LinkSharedDiaryButton";
 import DiaryIcon from "@/assets/icons/diary.svg";
 import WriteIcon from "@/assets/icons/write.svg";
 import SharedDiaryIcon from "@/assets/icons/shared-diary.svg";
-import Link from "next/link";
 
 export default function LinkWriteButton() {
   const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import Button from "@/components/common/atoms/Button";
-import { submitDiary, submitUpdateDiary } from "@/lib/api/write-diary";
+import {
+  deleteDraft,
+  submitDiary,
+  submitUpdateDiary,
+} from "@/lib/api/write-diary";
 import { resetDiary } from "@/store/diarySlice";
 import { resetPicture } from "@/store/pictureSlice";
 import { RootState } from "@/store/store";
@@ -18,6 +22,8 @@ export default function CreateDiaryButton() {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const dispatch = useDispatch();
   const {
+    isDraft,
+    draftId,
     title,
     content,
     picture,
@@ -60,6 +66,7 @@ export default function CreateDiaryButton() {
           );
         } else {
           // 새로 작성
+          console.log("임시저장 살태 : ", draftId, isDraft);
           await submitDiary({
             title,
             content,
@@ -73,6 +80,10 @@ export default function CreateDiaryButton() {
             feeling,
             privateStatus,
           });
+          if (isDraft && typeof draftId === "number") {
+            await deleteDraft(draftId);
+            console.log("임시저장 삭제 완료");
+          }
         }
 
         await Promise.all([dispatch(resetDiary()), dispatch(resetPicture())]);

--- a/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
@@ -6,7 +6,7 @@ import { resetDiary } from "@/store/diarySlice";
 import { resetPicture } from "@/store/pictureSlice";
 import { RootState } from "@/store/store";
 import { useRouter, useSearchParams } from "next/navigation";
-import { startTransition, useState } from "react";
+import { startTransition, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 export default function CreateDiaryButton() {
@@ -14,6 +14,7 @@ export default function CreateDiaryButton() {
   const diaryId: number | null = Number(searchParams.get("id")) || null;
 
   const router = useRouter();
+  const isSubmittingRef = useRef<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const dispatch = useDispatch();
   const {
@@ -33,9 +34,11 @@ export default function CreateDiaryButton() {
       return;
     }
 
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+
     startTransition(async () => {
-      if (isSubmitting) return;
-      setIsSubmitting(true);
       try {
         if (diaryId) {
           // 수정
@@ -78,7 +81,10 @@ export default function CreateDiaryButton() {
       } catch (error) {
         console.error("일기 작성 실패:", error);
       } finally {
-        setTimeout(() => setIsSubmitting(false), 500);
+        setTimeout(() => {
+          isSubmittingRef.current = false;
+          setIsSubmitting(false);
+        }, 500);
       }
     });
   }

--- a/mongeul/src/components/write-diary/atoms/CreateDraftButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDraftButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { submitDiaryDraft } from "@/lib/api/write-diary";
+import { submitDiaryDraft, submitUpdateDiary } from "@/lib/api/write-diary";
 import { resetDiary } from "@/store/diarySlice";
 import { resetPicture } from "@/store/pictureSlice";
 import { RootState } from "@/store/store";
@@ -11,6 +11,8 @@ export default function CreateDraftButton() {
   const dispatch = useDispatch();
   const router = useRouter();
   const {
+    isDraft,
+    draftId,
     title,
     content,
     date,
@@ -29,28 +31,59 @@ export default function CreateDraftButton() {
       return;
     }
 
-    try {
-      await submitDiaryDraft({
-        title,
-        content,
-        pictureLines:
-          typeof pictureLines === "string"
-            ? JSON.parse(pictureLines)
-            : pictureLines,
-        date,
-        weather,
-        feeling,
-        privateStatus,
-      });
-      dispatch(resetDiary());
-      dispatch(resetPicture());
+    // 임시저장 수정
+    if (isDraft && draftId) {
+      try {
+        await submitUpdateDiary(
+          {
+            title,
+            content,
+            pictureLines:
+              typeof pictureLines === "string"
+                ? JSON.parse(pictureLines)
+                : pictureLines,
+            date,
+            weather,
+            feeling,
+            privateStatus,
+          },
+          draftId
+        );
+        dispatch(resetDiary());
+        dispatch(resetPicture());
 
-      // Redux 상태 변경 후 반영될 시간을 확보
-      await new Promise((resolve) => setTimeout(resolve, 0));
+        // Redux 상태 변경 후 반영될 시간을 확보
+        await new Promise((resolve) => setTimeout(resolve, 0));
 
-      router.push("/diary");
-    } catch (error) {
-      console.error("일기 임시저장 실패:", error);
+        router.push("/diary");
+      } catch (error) {
+        console.error("일기 임시저장 실패:", error);
+      }
+    } else {
+      // 발행된 일기 수정
+      try {
+        await submitDiaryDraft({
+          title,
+          content,
+          pictureLines:
+            typeof pictureLines === "string"
+              ? JSON.parse(pictureLines)
+              : pictureLines,
+          date,
+          weather,
+          feeling,
+          privateStatus,
+        });
+        dispatch(resetDiary());
+        dispatch(resetPicture());
+
+        // Redux 상태 변경 후 반영될 시간을 확보
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        router.push("/diary");
+      } catch (error) {
+        console.error("일기 임시저장 실패:", error);
+      }
     }
   }
   return (

--- a/mongeul/src/components/write-diary/atoms/DraftItem.tsx
+++ b/mongeul/src/components/write-diary/atoms/DraftItem.tsx
@@ -10,6 +10,8 @@ import {
   setTitle,
   setWeather,
   setPictureLines,
+  setIsDraft,
+  setDraftId,
 } from "@/store/diarySlice";
 import { useDispatch } from "react-redux";
 import { updateLines } from "@/store/pictureSlice";
@@ -64,6 +66,8 @@ export default function DraftItem({
     dispatch(setFeeling(draft.feeling));
     dispatch(setPrivateStatus(draft.privateStatus));
     dispatch(setWeather(draft.weather));
+    dispatch(setIsDraft(true));
+    dispatch(setDraftId(draft.diaryId));
 
     onClose();
   };

--- a/mongeul/src/components/write-diary/atoms/DraftItem.tsx
+++ b/mongeul/src/components/write-diary/atoms/DraftItem.tsx
@@ -1,7 +1,13 @@
+"use client";
+
 import { Diary, Draft } from "@/types/diaryTypes";
 import { formatDate } from "@/utils/formatDate";
 import CloseIcon from "@/assets/icons/close.svg";
-import { deleteDraft, fetchPictureLines } from "@/lib/api/write-diary";
+import {
+  deleteDraft,
+  fetchIsWrite,
+  fetchPictureLines,
+} from "@/lib/api/write-diary";
 import {
   setContent,
   setDate,
@@ -17,6 +23,9 @@ import {
 import { useDispatch } from "react-redux";
 import { updateLines } from "@/store/pictureSlice";
 import { convertLinesToImage } from "@/utils/convertLinesToImage";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import UpdateAlertModal from "../molecules/UpdateAlertModal";
 
 interface DraftItemProps {
   draft: Draft;
@@ -30,6 +39,9 @@ export default function DraftItem({
   onClose,
 }: DraftItemProps) {
   const dispatch = useDispatch();
+  const router = useRouter();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [pendingDiaryId, setPendingDiaryId] = useState<number | null>(null);
 
   // 임시저장 일기 삭제
   const handleDelete = async (diaryId: number) => {
@@ -48,7 +60,10 @@ export default function DraftItem({
       const pictureLinesResponse = await fetchPictureLines(diaryId);
       console.log(pictureLinesResponse);
 
-      if (pictureLinesResponse.pictureLines) {
+      if (
+        pictureLinesResponse.pictureLines &&
+        pictureLinesResponse.pictureLines.length > 0
+      ) {
         // Redux 상태 업데이트
         dispatch(setPictureLines(pictureLinesResponse.pictureLines));
         dispatch(updateLines(pictureLinesResponse.pictureLines));
@@ -65,7 +80,21 @@ export default function DraftItem({
   };
 
   // 임시저장 일기 선택
-  const onSelectDraft = (draft: Diary) => {
+  const onSelectDraft = async (draft: Diary) => {
+    const isDiary = await fetchIsWrite(draft.date);
+
+    if (isDiary?.data) {
+      // 이미 작성된 날짜의 임시저장 일기라면 모달 표시
+      setPendingDiaryId(isDiary.data);
+      setIsModalOpen(true);
+    } else {
+      // 새롭게 작성하는 경우
+      proceedToEdit(draft);
+    }
+  };
+
+  // 확인 버튼을 눌렀을 때만 페이지 이동
+  const proceedToEdit = (draft: Diary) => {
     handlePictureLines(draft.diaryId);
     dispatch(setTitle(draft.title));
     dispatch(setContent(draft.content));
@@ -77,6 +106,11 @@ export default function DraftItem({
     dispatch(setDraftId(draft.diaryId));
 
     onClose();
+
+    if (pendingDiaryId) {
+      router.push(`/write-diary?id=${pendingDiaryId}`);
+      setPendingDiaryId(null);
+    }
   };
 
   return (
@@ -109,6 +143,13 @@ export default function DraftItem({
       >
         <CloseIcon className="h-4 w-4 text-gray-300" />
       </button>
+      {isModalOpen && (
+        <UpdateAlertModal
+          closeModal={() => setIsModalOpen(false)}
+          onConfirm={() => proceedToEdit(draft)}
+          date={formatDate(draft.date)}
+        />
+      )}
     </div>
   );
 }

--- a/mongeul/src/components/write-diary/atoms/DraftItem.tsx
+++ b/mongeul/src/components/write-diary/atoms/DraftItem.tsx
@@ -12,9 +12,11 @@ import {
   setPictureLines,
   setIsDraft,
   setDraftId,
+  setPicture,
 } from "@/store/diarySlice";
 import { useDispatch } from "react-redux";
 import { updateLines } from "@/store/pictureSlice";
+import { convertLinesToImage } from "@/utils/convertLinesToImage";
 
 interface DraftItemProps {
   draft: Draft;
@@ -39,18 +41,23 @@ export default function DraftItem({
     }
   };
 
-  // 임시저장 일기 라인 조회
+  // 임시저장 일기 라인 조회 후 이미지 변환
   const handlePictureLines = async (diaryId: number) => {
+    console.log("임시저장 일기 불러오기");
     try {
       const pictureLinesResponse = await fetchPictureLines(diaryId);
       console.log(pictureLinesResponse);
 
       if (pictureLinesResponse.pictureLines) {
-        // diary Redux에 라인 저장
+        // Redux 상태 업데이트
         dispatch(setPictureLines(pictureLinesResponse.pictureLines));
-
-        // picture Redux에 라인 저장
         dispatch(updateLines(pictureLinesResponse.pictureLines));
+
+        // 캔버스를 만들고 이미지 변환 후 Redux 저장
+        const imageDataUrl = await convertLinesToImage(
+          pictureLinesResponse.pictureLines
+        );
+        dispatch(setPicture(imageDataUrl));
       }
     } catch (error) {
       console.error("일기 라인 불러오기 실패", error);

--- a/mongeul/src/components/write-diary/molecules/UpdateAlertModal.tsx
+++ b/mongeul/src/components/write-diary/molecules/UpdateAlertModal.tsx
@@ -1,0 +1,37 @@
+import Button from "@/components/common/atoms/Button";
+import WebModal from "@/components/common/atoms/WebModal";
+
+export default function UpdateAlertModal({
+  closeModal,
+  onConfirm,
+  date,
+}: {
+  closeModal: () => void;
+  onConfirm: () => void;
+  date: string;
+}) {
+  return (
+    <WebModal onClose={closeModal}>
+      <div className="flex flex-col justify-center items-center gap-4">
+        <p>이미 일기가 작성된 날짜 입니다.</p>
+        <div className="flex flex-col justify-center items-center">
+          <p>
+            임시저장 일기를 가지고
+            <span className="text-theme-600"> {date}</span>의
+          </p>
+          <p>수정페이지로 이동할까요?</p>
+        </div>
+        <div className="flex gap-4">
+          <Button text={"확인"} onClick={onConfirm} textColor="text-white" />
+          <Button
+            text={"취소"}
+            onClick={closeModal}
+            backgroundColor="bg-white"
+            borderColor="border border-theme-400"
+            textColor="text-theme-400"
+          />
+        </div>
+      </div>
+    </WebModal>
+  );
+}

--- a/mongeul/src/components/write-diary/organisms/DateInputCard.tsx
+++ b/mongeul/src/components/write-diary/organisms/DateInputCard.tsx
@@ -13,24 +13,17 @@ import { fetchDiaryDates } from "@/lib/api/write-diary";
 
 function ModalContent({ closeModal }: { closeModal: () => void }) {
   const dispatch = useDispatch();
-  const selectedDate: string = useSelector(
-    (state: RootState) => state.diary.date
-  );
-  const parsedDate =
-    selectedDate && !isNaN(Date.parse(selectedDate))
-      ? new Date(selectedDate)
-      : new Date();
-
+  const selectedDate = useSelector((state: RootState) => state.diary.date);
+  const parsedDate = new Date(selectedDate || new Date());
   const [disabledDates, setDisabledDates] = useState<Date[]>([]);
+  const [currentMonth, setCurrentMonth] = useState(parsedDate.getMonth());
+  const [currentYear, setCurrentYear] = useState(parsedDate.getFullYear());
 
-  // 작성된 날짜의 일기 disabled
+  // ✅ 월 변경 시 작성된 날짜 조회
   useEffect(() => {
     async function loadDiaryDates() {
       try {
-        const year = new Date().getFullYear();
-        const month = new Date().getMonth() + 1;
-        const response = await fetchDiaryDates(year, month);
-
+        const response = await fetchDiaryDates(currentYear, currentMonth + 1);
         if (response.success) {
           const disabled = response.data.map((item) => new Date(item.date));
           setDisabledDates(disabled);
@@ -39,16 +32,29 @@ function ModalContent({ closeModal }: { closeModal: () => void }) {
         console.error("일기 날짜 조회 실패:", error);
       }
     }
-
     loadDiaryDates();
-  }, []);
+  }, [currentMonth, currentYear]); // ✅ 달이 바뀔 때마다 실행
+
+  // ✅ 현재 보고 있는 달의 날짜만 보이도록 설정
+  const renderDayContents = (day: number, date: Date) => {
+    return date.getMonth() === currentMonth ? (
+      <span>{day}</span>
+    ) : (
+      <span className="hidden"></span>
+    );
+  };
+
+  // ✅ 달 변경 감지해서 상태 업데이트
+  const handleMonthChange = (date: Date) => {
+    setCurrentMonth(date.getMonth());
+    setCurrentYear(date.getFullYear());
+  };
 
   // 날짜 선택
   const handleChange = (date: Date | null) => {
     if (!date) return;
     const formattedDate = date.toISOString().split("T")[0];
     dispatch(setDate(formattedDate));
-
     closeModal();
   };
 
@@ -58,8 +64,10 @@ function ModalContent({ closeModal }: { closeModal: () => void }) {
         inline
         selected={parsedDate}
         onChange={handleChange}
-        maxDate={new Date()}
-        excludeDates={disabledDates}
+        onMonthChange={handleMonthChange} // ✅ 월 변경 감지
+        maxDate={new Date()} // 미래 날짜 제한
+        excludeDates={disabledDates} // 작성된 날짜 비활성화
+        renderDayContents={renderDayContents} // ✅ 현재 달만 보이도록 설정
       />
     </div>
   );
@@ -67,19 +75,15 @@ function ModalContent({ closeModal }: { closeModal: () => void }) {
 
 export default function DateInputCard() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const selectedDate: string =
+  const selectedDate =
     useSelector((state: RootState) => state.diary.date) ??
-    new Date().toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
+    new Date().toISOString().split("T")[0];
 
-  const toggleModal = (): void => setIsModalOpen((prev) => !prev);
+  const toggleModal = () => setIsModalOpen((prev) => !prev);
 
   return (
     <>
-      <div className="w-full" onClick={() => toggleModal()}>
+      <div className="w-full" onClick={toggleModal}>
         <Card width="w-full">
           <div className="flex justify-center items-center w-full">
             {formatDate(selectedDate)}

--- a/mongeul/src/components/write-diary/organisms/PictureCard.tsx
+++ b/mongeul/src/components/write-diary/organisms/PictureCard.tsx
@@ -9,6 +9,7 @@ import { setPicture, setPictureLines } from "@/store/diarySlice";
 import CloseIcon from "@/assets/icons/close.svg";
 import PaletteIcon from "@/assets/icons/palette.svg";
 import { fetchPictureLines } from "@/lib/api/write-diary";
+import Image from "next/image";
 
 export default function PictureCard({ diaryId }: { diaryId: number | null }) {
   const dispatch = useDispatch();
@@ -53,7 +54,13 @@ export default function PictureCard({ diaryId }: { diaryId: number | null }) {
                 className="w-full flex justify-center items-center"
                 onClick={() => handlePictureLines(diaryId)}
               >
-                <img src={picture} alt="저장된 그림" />
+                <Image
+                  src={picture}
+                  alt="저장된 그림"
+                  width={500}
+                  height={500}
+                  layout="intrinsic"
+                />
               </div>
             </Link>
           </div>

--- a/mongeul/src/components/write-diary/templates/WriteForm.tsx
+++ b/mongeul/src/components/write-diary/templates/WriteForm.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useSearchParams } from "next/navigation";
 import ContentCard from "../organisms/ContentCard";
 import DateInputCard from "../organisms/DateInputCard";

--- a/mongeul/src/store/diarySlice.ts
+++ b/mongeul/src/store/diarySlice.ts
@@ -3,17 +3,21 @@ import { PictureLine } from "@/types/pictureTypes";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface DiaryState {
+  isDraft: boolean;
+  draftId: number | null;
   title: string;
   date: string;
   content: string;
   picture: string | null;
   pictureLines: PictureLine[] | null;
-  feeling: Feeling;
-  weather: Weather;
+  feeling: Feeling | null;
+  weather: Weather | null;
   privateStatus: PrivateStatus;
 }
 
 const initialState: DiaryState = {
+  isDraft: false,
+  draftId: null,
   title: "",
   date: new Date().toISOString().split("T")[0],
   content: "",
@@ -28,6 +32,12 @@ const diarySlice = createSlice({
   name: "diary",
   initialState,
   reducers: {
+    setIsDraft: (state, action: PayloadAction<boolean>) => {
+      state.isDraft = action.payload;
+    },
+    setDraftId: (state, action: PayloadAction<number | null>) => {
+      state.draftId = action.payload;
+    },
     setTitle: (state, action: PayloadAction<string>) => {
       state.title = action.payload;
     },
@@ -43,10 +53,10 @@ const diarySlice = createSlice({
     setPictureLines: (state, action: PayloadAction<PictureLine[] | null>) => {
       state.pictureLines = action.payload ?? [];
     },
-    setFeeling: (state, action: PayloadAction<Feeling>) => {
+    setFeeling: (state, action: PayloadAction<Feeling | null>) => {
       state.feeling = action.payload;
     },
-    setWeather: (state, action: PayloadAction<Weather>) => {
+    setWeather: (state, action: PayloadAction<Weather | null>) => {
       state.weather = action.payload;
     },
     setPrivateStatus: (state, action: PayloadAction<PrivateStatus>) => {
@@ -57,6 +67,8 @@ const diarySlice = createSlice({
 });
 
 export const {
+  setIsDraft,
+  setDraftId,
   setTitle,
   setDate,
   setContent,

--- a/mongeul/src/utils/convertLinesToImage.ts
+++ b/mongeul/src/utils/convertLinesToImage.ts
@@ -1,0 +1,34 @@
+import { PictureLine } from "@/types/pictureTypes";
+import Konva from "konva";
+
+export async function convertLinesToImage(
+  pictureLines: PictureLine[]
+): Promise<string> {
+  return new Promise((resolve) => {
+    // 가상 Konva Stage 생성 (DOM 없이 JS에서만 존재)
+    const stage = new Konva.Stage({
+      width: 500,
+      height: 500,
+      container: document.createElement("div"), // DOM에 추가하지 않고 메모리상에서만 사용
+    });
+
+    const layer = new Konva.Layer();
+
+    // 그림 데이터 추가
+    pictureLines.forEach((line) => {
+      const konvaLine = new Konva.Line({
+        points: line.points.flat(),
+        stroke: line.stroke,
+        strokeWidth: line.strokeWidth,
+        tension: 0.5,
+        lineCap: "round",
+        lineJoin: "round",
+      });
+      layer.add(konvaLine);
+    });
+
+    stage.add(layer);
+
+    resolve(stage.toDataURL({ mimeType: "image/png" }));
+  });
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1I1XQsa01HgYTOmyZzgQGk0bAsS5RyNvk%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=gvEqMtg)
# 📌 Pull Request

## 📋 변경 사항
- [ ] 설정
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 (설명 필요)

## 🔗 관련 이슈
- #78 

## 📜 변경 사항 설명
- 이미 작성된 날짜의 임시저장 선택시 모달 확인 후 해당 날짜의 수정 페이지로 네비게이션
- 임시저장 일기 불러올 때 저장된 그림 이미지 렌더링하는 유틸함수 생성
- 일기 작성 및 수정 중복 제출 방지
- 임시저장 글 중복 임시저장시 일기 수정 요청
- 임시저장 글 최종 발생시 해당 임시저장 일기 삭제
- 일기 날짜 선택 인풋 현재 선택한 달의 날짜만 렌더링

## 📸 스크린샷 (선택사항)
- UI 변경이 있거나 주요 기능이 추가되었다면 스크린샷을 첨부해주세요.
