### PR TITLE
Fix/89 picturesave

### DIFF
--- a/mongeul/package-lock.json
+++ b/mongeul/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.0.0",
         "react-datepicker": "^8.0.0",
         "react-dom": "^19.0.0",
+        "react-draggable": "^4.4.6",
         "react-konva": "^19.0.2",
         "react-loading-skeleton": "^3.5.0",
         "react-redux": "^9.2.0",
@@ -6373,7 +6374,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6665,7 +6665,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7170,7 +7169,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7251,11 +7249,33 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-konva": {

--- a/mongeul/package.json
+++ b/mongeul/package.json
@@ -22,6 +22,7 @@
     "react": "^19.0.0",
     "react-datepicker": "^8.0.0",
     "react-dom": "^19.0.0",
+    "react-draggable": "^4.4.6",
     "react-konva": "^19.0.2",
     "react-loading-skeleton": "^3.5.0",
     "react-redux": "^9.2.0",

--- a/mongeul/src/components/layout/SearchParamsProvider.tsx
+++ b/mongeul/src/components/layout/SearchParamsProvider.tsx
@@ -5,12 +5,15 @@ import { useSearchParams } from "next/navigation";
 export default function SearchParamsProvider({
   children,
 }: {
-  children: (diaryId: number | null) => React.ReactNode;
+  children: (diaryId: number | null, groupId: number | null) => React.ReactNode;
 }) {
   const searchParams = useSearchParams();
   const diaryId = searchParams.get("id")
     ? Number(searchParams.get("id"))
     : null;
+  const groupId = searchParams.get("groupid")
+    ? Number(searchParams.get("groupid"))
+    : null;
 
-  return <>{children(diaryId)}</>;
+  return <>{children(diaryId, groupId)}</>;
 }

--- a/mongeul/src/components/navbar/atoms/LinkPersonalDiaryButton.tsx
+++ b/mongeul/src/components/navbar/atoms/LinkPersonalDiaryButton.tsx
@@ -20,7 +20,7 @@ export default function LinkPersonalDiaryButton({
     const today = new Date().toISOString().split("T")[0];
     const isDiary = await verifyDiaryEntry(today);
 
-    if (isDiary) {
+    if (isDiary.data) {
       // 오늘 일기로 렌더링 또는 수정 페이지로 이동
       router.push(`/write-diary?id=${isDiary.data}`);
     } else {

--- a/mongeul/src/components/navbar/atoms/LinkSharedDiaryButton.tsx
+++ b/mongeul/src/components/navbar/atoms/LinkSharedDiaryButton.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { ReactElement } from "react";
+import { ReactElement, useEffect, useState } from "react";
+import WriteSharedDiaryModal from "../organisms/WriteSharedDIaryModal";
 
 interface LinkSharedDiaryButtonProps {
   text: string;
@@ -12,22 +13,29 @@ export default function LinkSharedDiaryButton({
   icon,
   toggleButton,
 }: LinkSharedDiaryButtonProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const toggleModal = () => setIsModalOpen((prev) => !prev);
+
   const writeSharedDiary = (): void => {
-    console.log("공유 다이어리 작성");
-    toggleButton();
+    toggleModal();
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 20 }}
-      transition={{ duration: 0.3 }}
-      className="bg-white shadow-md rounded-full px-4 py-3 flex items-center justify-center gap-2"
-      onClick={writeSharedDiary}
-    >
-      {icon}
-      {text}
-    </motion.div>
+    <>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 20 }}
+        transition={{ duration: 0.3 }}
+        className="bg-white shadow-md rounded-full px-4 py-3 flex items-center justify-center gap-2"
+        onClick={writeSharedDiary}
+      >
+        {icon}
+        {text}
+      </motion.div>
+      <AnimatePresence>
+        {isModalOpen && <WriteSharedDiaryModal onClose={toggleModal} />}
+      </AnimatePresence>
+    </>
   );
 }

--- a/mongeul/src/components/navbar/atoms/WriteSharedDiaryFriendItem.tsx
+++ b/mongeul/src/components/navbar/atoms/WriteSharedDiaryFriendItem.tsx
@@ -1,0 +1,26 @@
+import Button from "@/components/common/atoms/Button";
+
+interface WriteSharedDiaryFriendItemProps {
+  nickname: string;
+  friendId: number;
+}
+
+export default function WriteSharedDiaryFriendItem({
+  nickname,
+  friendId,
+}: WriteSharedDiaryFriendItemProps) {
+  const handleClick = () => {
+    console.log(`친구 클릭 ${nickname} ${friendId}`);
+  };
+  return (
+    <Button
+      width="w-full"
+      borderColor="border border-theme-400"
+      backgroundColor="bg-white"
+      textColor="text-theme-400"
+      padding="p-2"
+      text={nickname}
+      onClick={handleClick}
+    />
+  );
+}

--- a/mongeul/src/components/navbar/atoms/WriteSharedDiaryFriendItem.tsx
+++ b/mongeul/src/components/navbar/atoms/WriteSharedDiaryFriendItem.tsx
@@ -1,17 +1,22 @@
 import Button from "@/components/common/atoms/Button";
+import { useRouter } from "next/navigation";
 
 interface WriteSharedDiaryFriendItemProps {
   nickname: string;
-  friendId: number;
+  groupId: number;
 }
 
 export default function WriteSharedDiaryFriendItem({
   nickname,
-  friendId,
+  groupId,
 }: WriteSharedDiaryFriendItemProps) {
+  const router = useRouter();
+
   const handleClick = () => {
-    console.log(`친구 클릭 ${nickname} ${friendId}`);
+    console.log(`친구 클릭 ${nickname} ${groupId}`);
+    router.push(`/write-diary?groupid=${groupId}`);
   };
+
   return (
     <Button
       width="w-full"

--- a/mongeul/src/components/navbar/molecules/WriteSharedDiaryFriendList.tsx
+++ b/mongeul/src/components/navbar/molecules/WriteSharedDiaryFriendList.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import WriteSharedDiaryFriendItem from "../atoms/WriteSharedDiaryFriendItem";
+
+export default function WriteSharedDiaryFriendList() {
+  const [friends, setFriends] = useState([
+    { nickname: "나", friendId: 1 },
+    { nickname: "너", friendId: 2 },
+    { nickname: "쟤", friendId: 3 },
+  ]);
+
+  // useEffect(() => {
+
+  // }, [])
+
+  return (
+    <div className="w-full flex flex-col gap-4 py-4">
+      {friends.map((friend) => (
+        <WriteSharedDiaryFriendItem
+          key={friend.friendId}
+          friendId={friend.friendId}
+          nickname={friend.nickname}
+        />
+      ))}
+    </div>
+  );
+}

--- a/mongeul/src/components/navbar/molecules/WriteSharedDiaryFriendList.tsx
+++ b/mongeul/src/components/navbar/molecules/WriteSharedDiaryFriendList.tsx
@@ -4,15 +4,15 @@ import { WriteSharedDiaryItemSkeleton } from "@/components/skeletons";
 
 export default function WriteSharedDiaryFriendList() {
   const [loading, setIsLoading] = useState(true);
-  const [friends, setFriends] = useState([
-    { nickname: "나", friendId: 1 },
-    { nickname: "너", friendId: 2 },
-    { nickname: "쟤", friendId: 3 },
+  const [groups, setGroups] = useState([
+    { nickname: "나", groupId: 1 },
+    { nickname: "너", groupId: 2 },
+    { nickname: "쟤", groupId: 3 },
   ]);
 
-  // useEffect(() => {
-
-  // }, [])
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
 
   if (loading)
     return (
@@ -25,11 +25,11 @@ export default function WriteSharedDiaryFriendList() {
 
   return (
     <div className="w-full flex flex-col gap-4 py-4">
-      {friends.map((friend) => (
+      {groups.map((group) => (
         <WriteSharedDiaryFriendItem
-          key={friend.friendId}
-          friendId={friend.friendId}
-          nickname={friend.nickname}
+          key={group.groupId}
+          groupId={group.groupId}
+          nickname={group.nickname}
         />
       ))}
     </div>

--- a/mongeul/src/components/navbar/molecules/WriteSharedDiaryFriendList.tsx
+++ b/mongeul/src/components/navbar/molecules/WriteSharedDiaryFriendList.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import WriteSharedDiaryFriendItem from "../atoms/WriteSharedDiaryFriendItem";
+import { WriteSharedDiaryItemSkeleton } from "@/components/skeletons";
 
 export default function WriteSharedDiaryFriendList() {
+  const [loading, setIsLoading] = useState(true);
   const [friends, setFriends] = useState([
     { nickname: "나", friendId: 1 },
     { nickname: "너", friendId: 2 },
@@ -11,6 +13,15 @@ export default function WriteSharedDiaryFriendList() {
   // useEffect(() => {
 
   // }, [])
+
+  if (loading)
+    return (
+      <div className="w-full flex flex-col gap-2 py-4">
+        {[...Array(2)].map((_, index) => (
+          <WriteSharedDiaryItemSkeleton key={index} />
+        ))}
+      </div>
+    );
 
   return (
     <div className="w-full flex flex-col gap-4 py-4">

--- a/mongeul/src/components/navbar/organisms/WriteSharedDIaryModal.tsx
+++ b/mongeul/src/components/navbar/organisms/WriteSharedDIaryModal.tsx
@@ -1,0 +1,22 @@
+import WebModal from "@/components/common/atoms/WebModal";
+import WriteSharedDiaryFriendList from "../molecules/WriteSharedDiaryFriendList";
+
+interface WriteSharedDiaryModalProps {
+  onClose: () => void;
+}
+
+export default function WriteSharedDiaryModal({
+  onClose,
+}: WriteSharedDiaryModalProps) {
+  return (
+    <WebModal onClose={onClose}>
+      <div className="w-full flex flex-col justify-center items-center gap-6">
+        <p>교환 일기 작성</p>
+        <p className="text-sm">
+          지금 교환일기를 작성할 수 있는 친구목록이에요!
+        </p>
+        <WriteSharedDiaryFriendList />
+      </div>
+    </WebModal>
+  );
+}

--- a/mongeul/src/components/skeletons/DraftItemSkeleton.tsx
+++ b/mongeul/src/components/skeletons/DraftItemSkeleton.tsx
@@ -1,0 +1,11 @@
+import Skeleton from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+
+export default function DraftItemSkeleton() {
+  return (
+    <div className="p-4 w-full rounded-3xl h-auto bg-white">
+      <Skeleton width="40%" height={20} />
+      <Skeleton width="100%" height={25} />
+    </div>
+  );
+}

--- a/mongeul/src/components/skeletons/WriteSharedDiaryItemSkeleton.tsx
+++ b/mongeul/src/components/skeletons/WriteSharedDiaryItemSkeleton.tsx
@@ -1,0 +1,10 @@
+import Skeleton from "react-loading-skeleton";
+import "react-loading-skeleton/dist/skeleton.css";
+
+export default function WriteSharedDiaryItemSkeleton() {
+  return (
+    <div className="w-full rounded-3xl h-auto bg-white items-center justify-center">
+      <Skeleton width="100%" height={40} borderRadius={20} />
+    </div>
+  );
+}

--- a/mongeul/src/components/skeletons/index.ts
+++ b/mongeul/src/components/skeletons/index.ts
@@ -1,1 +1,2 @@
 export { default as DiaryDetailSkeleton } from "./DiaryDetailSkeleton";
+export { default as DraftItemSkeleton } from "./DraftItemSkeleton";

--- a/mongeul/src/components/skeletons/index.ts
+++ b/mongeul/src/components/skeletons/index.ts
@@ -1,2 +1,3 @@
 export { default as DiaryDetailSkeleton } from "./DiaryDetailSkeleton";
 export { default as DraftItemSkeleton } from "./DraftItemSkeleton";
+export { default as WriteSharedDiaryItemSkeleton } from "./WriteSharedDiaryItemSkeleton";

--- a/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
@@ -3,8 +3,10 @@
 import Button from "@/components/common/atoms/Button";
 import {
   createDiaryEntry,
+  createSharedDiaryEntry,
   deleteDiaryEntry,
   updateDiaryEntry,
+  updateSharedDiaryEntry,
 } from "@/lib/api/write-diary";
 import { resetDiary } from "@/store/diarySlice";
 import { resetPicture } from "@/store/pictureSlice";
@@ -16,9 +18,13 @@ import { useRouter } from "next/navigation";
 
 interface CreateDiaryButtonProps {
   diaryId: number | null;
+  groupId: number | null;
 }
 
-export default function CreateDiaryButton({ diaryId }: CreateDiaryButtonProps) {
+export default function CreateDiaryButton({
+  diaryId,
+  groupId,
+}: CreateDiaryButtonProps) {
   const router = useRouter();
   const isSubmittingRef = useRef<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -47,7 +53,8 @@ export default function CreateDiaryButton({ diaryId }: CreateDiaryButtonProps) {
     setIsSubmitting(true);
 
     try {
-      if (diaryId) {
+      if (diaryId && groupId === null) {
+        // 개인 일기 수정
         await updateDiaryEntry(
           {
             title,
@@ -64,7 +71,8 @@ export default function CreateDiaryButton({ diaryId }: CreateDiaryButtonProps) {
           },
           diaryId
         );
-      } else {
+      } else if (diaryId === null && groupId === null) {
+        // 개인 일기 작성
         await createDiaryEntry({
           title,
           content,
@@ -82,23 +90,67 @@ export default function CreateDiaryButton({ diaryId }: CreateDiaryButtonProps) {
         if (isDraft && typeof draftId === "number") {
           await deleteDiaryEntry(draftId);
         }
+      } else if (diaryId === null && groupId) {
+        // 공유 일기 작성
+        await createSharedDiaryEntry(
+          {
+            title,
+            content,
+            picture: picture || "",
+            pictureLines:
+              typeof pictureLines === "string"
+                ? JSON.parse(pictureLines)
+                : pictureLines,
+            date,
+            weather,
+            feeling,
+            privateStatus,
+          },
+          groupId
+        );
+
+        if (isDraft && typeof draftId === "number") {
+          await deleteDiaryEntry(draftId);
+        }
+      } else if (diaryId !== null && groupId) {
+        // 공유 일기 수정
+        await updateSharedDiaryEntry(
+          {
+            title,
+            content,
+            picture: picture || "",
+            pictureLines:
+              typeof pictureLines === "string"
+                ? JSON.parse(pictureLines)
+                : pictureLines,
+            date,
+            weather,
+            feeling,
+            privateStatus,
+          },
+          diaryId,
+          groupId
+        );
       }
 
-      await Promise.all([dispatch(resetDiary()), dispatch(resetPicture())]);
-      router.push("/diary");
+      // 상태 초기화 및 페이지 이동
+      dispatch(resetDiary());
+      dispatch(resetPicture());
+      if (groupId !== null) {
+        router.push("/diary");
+      } else {
+        router.push("/shared-diary");
+      }
     } catch (error) {
       console.error("일기 작성 실패:", error);
     } finally {
-      setTimeout(() => {
-        isSubmittingRef.current = false;
-        setIsSubmitting(false);
-      }, 500);
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
     }
   }
 
   return (
     <>
-      {/* 일기 작성중 */}
       {isSubmitting && (
         <div className="fixed inset-0 flex items-center justify-center bg-gray-500 bg-opacity-50 z-50">
           <DiarySubmitSpinner />

--- a/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDiaryButton.tsx
@@ -42,110 +42,81 @@ export default function CreateDiaryButton({
     privateStatus,
   } = useSelector((state: RootState) => state.diary);
 
+  // API 요청 실행 후 상태 업데이트 및 페이지 이동
+  async function handleSaveDiary(
+    apiCall: () => Promise<any>,
+    redirectPath: string
+  ) {
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+
+    try {
+      await apiCall();
+      dispatch(resetDiary());
+      dispatch(resetPicture());
+
+      setTimeout(() => router.push(redirectPath), 50);
+    } catch (error) {
+      console.error("일기 저장 실패:", error);
+    } finally {
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+    }
+  }
+
+  // 일기 데이터
+  const diaryData = {
+    title,
+    content,
+    picture: picture || "",
+    pictureLines:
+      typeof pictureLines === "string"
+        ? JSON.parse(pictureLines)
+        : pictureLines,
+    date,
+    weather,
+    feeling,
+    privateStatus,
+  };
+
+  // 제출 핸들러
   async function handleSubmit() {
     if (!title || !content || !date || !weather || !feeling || !privateStatus) {
       alert("필수 입력 항목을 모두 입력해주세요!");
       return;
     }
 
-    if (isSubmittingRef.current) return;
-    isSubmittingRef.current = true;
-    setIsSubmitting(true);
+    if (diaryId && !groupId) {
+      // 개인 일기 수정
+      return handleSaveDiary(
+        () => updateDiaryEntry(diaryData, diaryId),
+        "/diary"
+      );
+    }
 
-    try {
-      if (diaryId && groupId === null) {
-        // 개인 일기 수정
-        await updateDiaryEntry(
-          {
-            title,
-            content,
-            picture: picture || "",
-            pictureLines:
-              typeof pictureLines === "string"
-                ? JSON.parse(pictureLines)
-                : pictureLines,
-            date,
-            weather,
-            feeling,
-            privateStatus,
-          },
-          diaryId
-        );
-      } else if (diaryId === null && groupId === null) {
-        // 개인 일기 작성
-        await createDiaryEntry({
-          title,
-          content,
-          picture: picture || "",
-          pictureLines:
-            typeof pictureLines === "string"
-              ? JSON.parse(pictureLines)
-              : pictureLines,
-          date,
-          weather,
-          feeling,
-          privateStatus,
-        });
+    if (!diaryId && !groupId) {
+      // 개인 일기 작성
+      return handleSaveDiary(async () => {
+        await createDiaryEntry(diaryData);
+        if (isDraft && draftId) await deleteDiaryEntry(draftId);
+      }, "/diary");
+    }
 
-        if (isDraft && typeof draftId === "number") {
-          await deleteDiaryEntry(draftId);
-        }
-      } else if (diaryId === null && groupId) {
-        // 공유 일기 작성
-        await createSharedDiaryEntry(
-          {
-            title,
-            content,
-            picture: picture || "",
-            pictureLines:
-              typeof pictureLines === "string"
-                ? JSON.parse(pictureLines)
-                : pictureLines,
-            date,
-            weather,
-            feeling,
-            privateStatus,
-          },
-          groupId
-        );
+    if (!diaryId && groupId) {
+      // 공유 일기 작성
+      return handleSaveDiary(async () => {
+        await createSharedDiaryEntry(diaryData, groupId);
+        if (isDraft && draftId) await deleteDiaryEntry(draftId);
+      }, "/shared-diary");
+    }
 
-        if (isDraft && typeof draftId === "number") {
-          await deleteDiaryEntry(draftId);
-        }
-      } else if (diaryId !== null && groupId) {
-        // 공유 일기 수정
-        await updateSharedDiaryEntry(
-          {
-            title,
-            content,
-            picture: picture || "",
-            pictureLines:
-              typeof pictureLines === "string"
-                ? JSON.parse(pictureLines)
-                : pictureLines,
-            date,
-            weather,
-            feeling,
-            privateStatus,
-          },
-          diaryId,
-          groupId
-        );
-      }
-
-      // 상태 초기화 및 페이지 이동
-      dispatch(resetDiary());
-      dispatch(resetPicture());
-      if (groupId !== null) {
-        router.push("/diary");
-      } else {
-        router.push("/shared-diary");
-      }
-    } catch (error) {
-      console.error("일기 작성 실패:", error);
-    } finally {
-      isSubmittingRef.current = false;
-      setIsSubmitting(false);
+    if (diaryId && groupId) {
+      // 공유 일기 수정
+      return handleSaveDiary(
+        () => updateSharedDiaryEntry(diaryData, groupId, diaryId),
+        "/shared-diary"
+      );
     }
   }
 

--- a/mongeul/src/components/write-diary/atoms/CreateDraftButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDraftButton.tsx
@@ -2,8 +2,9 @@
 
 import {
   createDiaryDraft,
-  createDiaryEntry,
+  createSharedDiaryDraft,
   updateDiaryEntry,
+  updateSharedDiaryEntry,
 } from "@/lib/api/write-diary";
 import { resetDiary } from "@/store/diarySlice";
 import { resetPicture } from "@/store/pictureSlice";
@@ -11,7 +12,11 @@ import { RootState } from "@/store/store";
 import { useRouter } from "next/navigation";
 import { useDispatch, useSelector } from "react-redux";
 
-export default function CreateDraftButton() {
+interface CreateDraftButtonProps {
+  groupId: number | null;
+}
+
+export default function CreateDraftButton({ groupId }: CreateDraftButtonProps) {
   const dispatch = useDispatch();
   const router = useRouter();
   const {
@@ -28,68 +33,74 @@ export default function CreateDraftButton() {
 
   const isDirty = !!(title || content || pictureLines || weather || feeling);
 
-  // 임시저장
+  // API 요청 실행 후 상태 업데이트 및 페이지 이동
+  async function handleSaveDiary(
+    apiCall: () => Promise<any>,
+    redirectPath: string
+  ) {
+    try {
+      const response = await apiCall(); // API 응답 받기
+      console.log("API 응답:", response);
+
+      dispatch(resetDiary());
+      dispatch(resetPicture());
+
+      setTimeout(() => router.push(redirectPath), 50);
+    } catch (error) {
+      console.error("일기 임시저장 실패:", error);
+    }
+  }
+
+  // 임시 저장 핸들러
   async function handleSubmit() {
     if (!isDirty) {
       alert("작성한 일기가 없습니다.");
       return;
     }
 
-    // 임시저장 수정
+    const diaryData = {
+      title,
+      content,
+      pictureLines:
+        typeof pictureLines === "string"
+          ? JSON.parse(pictureLines)
+          : pictureLines,
+      date,
+      weather,
+      feeling,
+      privateStatus,
+    };
+
+    // 개인 임기저장 일기 수정
     if (isDraft && draftId) {
-      try {
-        await updateDiaryEntry(
-          {
-            title,
-            content,
-            pictureLines:
-              typeof pictureLines === "string"
-                ? JSON.parse(pictureLines)
-                : pictureLines,
-            date,
-            weather,
-            feeling,
-            privateStatus,
-          },
-          draftId
-        );
-        dispatch(resetDiary());
-        dispatch(resetPicture());
+      return handleSaveDiary(
+        () => updateDiaryEntry(diaryData, draftId),
+        "/diary"
+      );
+    }
 
-        // Redux 상태 변경 후 반영될 시간을 확보
-        await new Promise((resolve) => setTimeout(resolve, 0));
+    // 새로운 임시저장 (개인 일기)
+    if (!groupId && !isDraft && !draftId) {
+      return handleSaveDiary(() => createDiaryDraft(diaryData), "/diary");
+    }
 
-        router.push("/diary");
-      } catch (error) {
-        console.error("일기 임시저장 수정 실패:", error);
-      }
-    } else {
-      // 임시저장 생성
-      try {
-        await createDiaryDraft({
-          title,
-          content,
-          pictureLines:
-            typeof pictureLines === "string"
-              ? JSON.parse(pictureLines)
-              : pictureLines,
-          date,
-          weather,
-          feeling,
-          privateStatus,
-        });
-        dispatch(resetDiary());
-        dispatch(resetPicture());
+    // 새로운 임시저장 (공유 일기)
+    if (groupId && !isDraft && !draftId) {
+      return handleSaveDiary(
+        () => createSharedDiaryDraft(diaryData, groupId),
+        "/shared-diary"
+      );
+    }
 
-        // Redux 상태 변경 후 반영될 시간을 확보
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
-        router.push("/diary");
-      } catch (error) {
-        console.error("일기 임시저장 실패:", error);
-      }
+    // 공유 임시저장 일기 수정
+    if (groupId && isDraft && draftId) {
+      return handleSaveDiary(
+        () => updateSharedDiaryEntry(diaryData, groupId, draftId),
+        "/shared-diary"
+      );
     }
   }
+
   return (
     <button className="w-full text-gray-500" onClick={handleSubmit}>
       임시저장

--- a/mongeul/src/components/write-diary/atoms/CreateDraftButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/CreateDraftButton.tsx
@@ -39,7 +39,7 @@ export default function CreateDraftButton({ groupId }: CreateDraftButtonProps) {
     redirectPath: string
   ) {
     try {
-      const response = await apiCall(); // API 응답 받기
+      const response = await apiCall();
       console.log("API 응답:", response);
 
       dispatch(resetDiary());

--- a/mongeul/src/components/write-diary/atoms/DraftItem.tsx
+++ b/mongeul/src/components/write-diary/atoms/DraftItem.tsx
@@ -7,7 +7,9 @@ import {
   deleteDiaryEntry,
   deleteSharedDiaryEntry,
   fetchPictureLines,
+  fetchSharedPictureLines,
   verifyDiaryEntry,
+  verifySharedDiaryEntry,
 } from "@/lib/api/write-diary";
 import {
   setContent,
@@ -61,7 +63,10 @@ export default function DraftItem({
   // 임시저장 일기 라인 조회 후 이미지 변환
   const handlePictureLines = async (diaryId: number) => {
     try {
-      const response = await fetchPictureLines(diaryId);
+      const response = await (groupId
+        ? fetchSharedPictureLines(diaryId)
+        : fetchPictureLines(diaryId));
+
       const pictureLines = response.data.pictureLines;
 
       if (pictureLines?.length > 0) {
@@ -80,7 +85,9 @@ export default function DraftItem({
   // 임시저장 일기 선택
   const onSelectDraft = async (draft: Diary) => {
     try {
-      const isDiary = await verifyDiaryEntry(draft.date);
+      const isDiary = await (groupId
+        ? verifySharedDiaryEntry(draft.date, groupId)
+        : verifyDiaryEntry(draft.date));
 
       if (isDiary?.data) {
         // 이미 작성된 날짜의 임시저장 일기라면 모달 표시

--- a/mongeul/src/components/write-diary/atoms/DraftItem.tsx
+++ b/mongeul/src/components/write-diary/atoms/DraftItem.tsx
@@ -5,6 +5,7 @@ import { formatDate } from "@/utils/formatDate";
 import CloseIcon from "@/assets/icons/close.svg";
 import {
   deleteDiaryEntry,
+  deleteSharedDiaryEntry,
   fetchPictureLines,
   verifyDiaryEntry,
 } from "@/lib/api/write-diary";
@@ -29,12 +30,14 @@ import UpdateAlertModal from "../molecules/UpdateAlertModal";
 
 interface DraftItemProps {
   draft: Draft;
+  groupId: number | null;
   onDelete: (diaryId: number) => void;
   onClose: () => void;
 }
 
 export default function DraftItem({
   draft,
+  groupId,
   onDelete,
   onClose,
 }: DraftItemProps) {
@@ -46,7 +49,9 @@ export default function DraftItem({
   // 임시저장 일기 삭제
   const handleDelete = async (diaryId: number) => {
     try {
-      await deleteDiaryEntry(diaryId);
+      await (groupId
+        ? deleteSharedDiaryEntry(diaryId)
+        : deleteDiaryEntry(diaryId));
       onDelete(diaryId);
     } catch (error) {
       console.error("일기 삭제 실패:", error);
@@ -55,23 +60,16 @@ export default function DraftItem({
 
   // 임시저장 일기 라인 조회 후 이미지 변환
   const handlePictureLines = async (diaryId: number) => {
-    console.log("임시저장 일기 불러오기");
     try {
-      const pictureLinesResponse = await fetchPictureLines(diaryId);
-      console.log(pictureLinesResponse);
+      const response = await fetchPictureLines(diaryId);
+      const pictureLines = response.data.pictureLines;
 
-      if (
-        pictureLinesResponse.data.pictureLines &&
-        pictureLinesResponse.data.pictureLines.length > 0
-      ) {
-        // Redux 상태 업데이트
-        dispatch(setPictureLines(pictureLinesResponse.data.pictureLines));
-        dispatch(updateLines(pictureLinesResponse.data.pictureLines));
+      if (pictureLines?.length > 0) {
+        dispatch(setPictureLines(pictureLines));
+        dispatch(updateLines(pictureLines));
 
         // 캔버스를 만들고 이미지 변환 후 Redux 저장
-        const imageDataUrl = await convertLinesToImage(
-          pictureLinesResponse.data.pictureLines
-        );
+        const imageDataUrl = await convertLinesToImage(pictureLines);
         dispatch(setPicture(imageDataUrl));
       }
     } catch (error) {
@@ -81,21 +79,24 @@ export default function DraftItem({
 
   // 임시저장 일기 선택
   const onSelectDraft = async (draft: Diary) => {
-    const isDiary = await verifyDiaryEntry(draft.date);
+    try {
+      const isDiary = await verifyDiaryEntry(draft.date);
 
-    if (isDiary?.data) {
-      // 이미 작성된 날짜의 임시저장 일기라면 모달 표시
-      setPendingDiaryId(isDiary.data);
-      setIsModalOpen(true);
-    } else {
-      // 새롭게 작성하는 경우
-      proceedToEdit(draft);
+      if (isDiary?.data) {
+        // 이미 작성된 날짜의 임시저장 일기라면 모달 표시
+        setPendingDiaryId(isDiary.data);
+        setIsModalOpen(true);
+      } else {
+        proceedToEdit(draft);
+      }
+    } catch (error) {
+      console.error("일기 존재 여부 확인 실패", error);
     }
   };
 
   // 확인 버튼을 눌렀을 때만 페이지 이동
-  const proceedToEdit = (draft: Diary) => {
-    handlePictureLines(draft.diaryId);
+  const proceedToEdit = async (draft: Diary) => {
+    await handlePictureLines(draft.diaryId);
     dispatch(setTitle(draft.title));
     dispatch(setContent(draft.content));
     dispatch(setDate(draft.date));
@@ -106,16 +107,15 @@ export default function DraftItem({
     dispatch(setDraftId(draft.diaryId));
 
     onClose();
-
     if (pendingDiaryId) {
-      router.push(`/write-diary?id=${pendingDiaryId}`);
+      router.push(`/write-diary?id=${pendingDiaryId ?? draft.diaryId}`);
       setPendingDiaryId(null);
     }
   };
 
   return (
     <div className="w-full flex flex-row gap-2 p-4 border-b border-gray-100 last:border-b-0 relative">
-      {/* 제목, 날짜, 내용 클릭 가능 영역 */}
+      {/* 클릭 가능 영역 */}
       <div
         className="w-full flex flex-col gap-2 cursor-pointer"
         onClick={() => onSelectDraft(draft)}

--- a/mongeul/src/components/write-diary/atoms/DraftListButton.tsx
+++ b/mongeul/src/components/write-diary/atoms/DraftListButton.tsx
@@ -4,7 +4,11 @@ import { useState } from "react";
 import DraftListModal from "../organisms/DraftListModal";
 import MenuIcon from "@/assets/icons/menu.svg";
 
-export default function DraftListButton() {
+interface DraftListButtonProps {
+  groupId: number | null;
+}
+
+export default function DraftListButton({ groupId }: DraftListButtonProps) {
   const [isModalOepn, setIsModalOpen] = useState(false);
 
   const toggleButton = () => {
@@ -19,7 +23,9 @@ export default function DraftListButton() {
       >
         <MenuIcon className="text-gray-400 h-4 w-4" />
       </button>
-      {isModalOepn && <DraftListModal onClose={toggleButton} />}
+      {isModalOepn && (
+        <DraftListModal onClose={toggleButton} groupId={groupId} />
+      )}
     </>
   );
 }

--- a/mongeul/src/components/write-diary/molecules/DraftButtons.tsx
+++ b/mongeul/src/components/write-diary/molecules/DraftButtons.tsx
@@ -1,12 +1,16 @@
 import CreateDraftButton from "../atoms/CreateDraftButton";
 import DraftListButton from "../atoms/DraftListButton";
 
-export default function DraftButtons() {
+interface DraftButtonsProps {
+  groupId: number | null;
+}
+
+export default function DraftButtons({ groupId }: DraftButtonsProps) {
   return (
     <div className="w-full flex flex-row rounded-3xl py-2 bg-white border border-theme-400">
-      <CreateDraftButton />
+      <CreateDraftButton groupId={groupId} />
       <div className="border-l border-theme-200" />
-      <DraftListButton />
+      <DraftListButton groupId={groupId} />
     </div>
   );
 }

--- a/mongeul/src/components/write-diary/molecules/DraftList.tsx
+++ b/mongeul/src/components/write-diary/molecules/DraftList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { fetchDiaryDraft } from "@/lib/api/write-diary";
 import { Draft } from "@/types/diaryTypes";
 import DraftItem from "../atoms/DraftItem";
+import { DraftItemSkeleton } from "@/components/skeletons";
 
 interface DraftListProps {
   onClose: () => void;
@@ -39,7 +40,8 @@ export default function DraftList({ onClose }: DraftListProps) {
     );
   };
 
-  if (loading) return <div>로딩 중...</div>;
+  if (loading)
+    return [...Array(2)].map((_, index) => <DraftItemSkeleton key={index} />);
   if (error) return <div>{error}</div>;
 
   return (
@@ -54,7 +56,7 @@ export default function DraftList({ onClose }: DraftListProps) {
           />
         ))
       ) : (
-        <div className="text-xs text-gray-400 p-4 w-full h-40 flex justify-center items-center">
+        <div className="text-xs text-gray-400 p-4 w-full h-20 flex justify-center items-center">
           임시저장된 일기가 없습니다.
         </div>
       )}

--- a/mongeul/src/components/write-diary/molecules/DraftList.tsx
+++ b/mongeul/src/components/write-diary/molecules/DraftList.tsx
@@ -1,65 +1,80 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { fetchDiaryDraft } from "@/lib/api/write-diary";
+import { useEffect, useState, useCallback } from "react";
+import { fetchDiaryDraft, fetchSharedDiaryDraft } from "@/lib/api/write-diary";
 import { Draft } from "@/types/diaryTypes";
 import DraftItem from "../atoms/DraftItem";
 import { DraftItemSkeleton } from "@/components/skeletons";
 
 interface DraftListProps {
   onClose: () => void;
+  groupId: number | null;
 }
 
-export default function DraftList({ onClose }: DraftListProps) {
+export default function DraftList({ onClose, groupId }: DraftListProps) {
   const [drafts, setDrafts] = useState<Draft[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function loadDrafts() {
-      try {
-        const data = await fetchDiaryDraft();
-        if (data.success && data.data) {
-          setDrafts(data.data);
-        } else {
-          setError("임시저장 목록을 불러오는 데 실패했습니다.");
-        }
-      } catch (err) {
-        console.error("임시저장 목록 조회 실패:", err);
-      } finally {
-        setLoading(false);
+  // useCallback으로 loadDrafts 감싸기
+  const loadDrafts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = groupId
+        ? await fetchSharedDiaryDraft(groupId)
+        : await fetchDiaryDraft();
+      if (data.success && data.data) {
+        setDrafts(data.data);
+      } else {
+        setError(
+          groupId
+            ? "공유일기 임시저장 목록을 불러오는 데 실패했습니다."
+            : "개인일기 임시저장 목록을 불러오는 데 실패했습니다."
+        );
       }
+    } catch (err) {
+      console.error(
+        groupId
+          ? "공유일기 임시저장 목록 조회 실패:"
+          : "개인일기 임시저장 목록 조회 실패:",
+        err
+      );
+      setError("데이터를 불러오는 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
     }
-    loadDrafts();
-  }, []);
+  }, [groupId]);
 
-  // 임시저장 일기 삭제
+  useEffect(() => {
+    loadDrafts();
+  }, [loadDrafts]);
+
+  // 임시저장 일기 삭제 핸들러
   const handleDeleteDraft = (diaryId: number) => {
     setDrafts((prevDrafts) =>
       prevDrafts.filter((draft) => draft.diaryId !== diaryId)
     );
   };
 
-  if (loading)
-    return [...Array(2)].map((_, index) => <DraftItemSkeleton key={index} />);
-  if (error) return <div>{error}</div>;
-
-  return (
-    <div className="w-full gap-3">
-      {drafts.length > 0 ? (
-        drafts.map((draft) => (
-          <DraftItem
-            key={draft.diaryId}
-            draft={draft}
-            onDelete={handleDeleteDraft}
-            onClose={onClose}
-          />
-        ))
-      ) : (
+  const renderContent = () => {
+    if (loading)
+      return [...Array(2)].map((_, index) => <DraftItemSkeleton key={index} />);
+    if (error) return <div className="text-red-500">{error}</div>;
+    if (drafts.length === 0)
+      return (
         <div className="text-xs text-gray-400 p-4 w-full h-20 flex justify-center items-center">
           임시저장된 일기가 없습니다.
         </div>
-      )}
-    </div>
-  );
+      );
+
+    return drafts.map((draft) => (
+      <DraftItem
+        key={draft.diaryId}
+        groupId={groupId}
+        draft={draft}
+        onDelete={handleDeleteDraft}
+        onClose={onClose}
+      />
+    ));
+  };
+
+  return <div className="w-full gap-3">{renderContent()}</div>;
 }

--- a/mongeul/src/components/write-diary/molecules/WriteDiaryNavBar.tsx
+++ b/mongeul/src/components/write-diary/molecules/WriteDiaryNavBar.tsx
@@ -11,8 +11,8 @@ export default function WriteDiaryNavBar() {
       <SearchParamsProvider>
         {(diaryId, groupId) => (
           <div className="w-full px-0 flex flex-row gap-2">
-            <CreateDiaryButton diaryId={diaryId} groupId={null} />
-            {diaryId === null && <DraftButtons />}
+            <CreateDiaryButton diaryId={diaryId} groupId={groupId} />
+            {diaryId === null && <DraftButtons groupId={groupId} />}
           </div>
         )}
       </SearchParamsProvider>

--- a/mongeul/src/components/write-diary/molecules/WriteDiaryNavBar.tsx
+++ b/mongeul/src/components/write-diary/molecules/WriteDiaryNavBar.tsx
@@ -9,9 +9,9 @@ export default function WriteDiaryNavBar() {
   return (
     <Suspense>
       <SearchParamsProvider>
-        {(diaryId) => (
+        {(diaryId, groupId) => (
           <div className="w-full px-0 flex flex-row gap-2">
-            <CreateDiaryButton diaryId={diaryId} />
+            <CreateDiaryButton diaryId={diaryId} groupId={null} />
             {diaryId === null && <DraftButtons />}
           </div>
         )}

--- a/mongeul/src/components/write-diary/organisms/Canvas.tsx
+++ b/mongeul/src/components/write-diary/organisms/Canvas.tsx
@@ -4,7 +4,7 @@ const KonvaCanvas = dynamic(() => import("./KonvaCanvas"), { ssr: false });
 
 export default function Canvas() {
   return (
-    <div>
+    <div className="w-full">
       <KonvaCanvas />
     </div>
   );

--- a/mongeul/src/components/write-diary/organisms/DraftListModal.tsx
+++ b/mongeul/src/components/write-diary/organisms/DraftListModal.tsx
@@ -3,15 +3,19 @@ import DraftList from "../molecules/DraftList";
 
 interface DraftListModalProps {
   onClose: () => void;
+  groupId: number | null;
 }
 
-export default function DraftListModal({ onClose }: DraftListModalProps) {
+export default function DraftListModal({
+  onClose,
+  groupId,
+}: DraftListModalProps) {
   return (
     <WebModal padding="" onClose={onClose}>
       <div className="text-sm pb-2 flex justify-center">임시 저장 목록</div>
       <div className="w-80 max-h-96 flex flex-col items-center gap-4 overflow-y-auto scrollbar-hide">
         <div className="w-full flex-grow">
-          <DraftList onClose={onClose} />
+          <DraftList onClose={onClose} groupId={groupId} />
         </div>
       </div>
     </WebModal>

--- a/mongeul/src/components/write-diary/organisms/KonvaCanvas.tsx
+++ b/mongeul/src/components/write-diary/organisms/KonvaCanvas.tsx
@@ -2,10 +2,15 @@ import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { RootState } from "@/store/store";
 import { useDispatch, useSelector } from "react-redux";
-import { addLine, updateLines } from "@/store/pictureSlice";
+import {
+  addLine,
+  updateLines,
+  updateLinesWithHistory,
+} from "@/store/pictureSlice";
 import Card from "@/components/common/atoms/Card";
 import { setStageRef } from "@/utils/stateRef";
 import { Stage, Layer, Line } from "react-konva";
+import { PictureLine } from "@/types/pictureTypes";
 
 const KonvaCanvas = () => {
   const dispatch = useDispatch();
@@ -16,6 +21,7 @@ const KonvaCanvas = () => {
   const stageRef = useRef<any>(null);
   const [isDrawing, setIsDrawing] = useState<boolean>(false);
   const [isClient, setIsClient] = useState(false);
+  const prevLinesBeforeErase = useRef<PictureLine[] | null>(null);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -27,12 +33,10 @@ const KonvaCanvas = () => {
     if (stageRef.current) {
       setStageRef(stageRef.current);
       console.log("stageRef 설정됨:", stageRef.current);
-    } else {
-      console.warn("stageRef가 아직 설정되지 않았습니다.");
     }
-  }, [stageRef.current]); // `stageRef.current` 변경될 때 실행
+  }, [stageRef.current]);
 
-  if (!isClient) return null; // 서버에서 실행되지 않도록 방어
+  if (!isClient) return null;
 
   const changeOpacity = (color: string, opacity: number) => {
     if (color.startsWith("rgba")) return color;
@@ -47,13 +51,14 @@ const KonvaCanvas = () => {
 
   // 그림 그리기 시작
   const handleMouseDown = (e: any) => {
+    setIsDrawing(true);
+
     if (selectedBrush === "eraser") {
-      setIsDrawing(true);
-      handleErase(e); // 마우스를 누르자마자 바로 지우기 실행
+      prevLinesBeforeErase.current = [...lines];
+      handleErase(e, false);
       return;
     }
 
-    setIsDrawing(true);
     const pos = e.target.getStage().getPointerPosition();
     if (!pos) return;
 
@@ -64,11 +69,12 @@ const KonvaCanvas = () => {
     );
   };
 
-  // 그리는 중 or 지우는 중
+  // 그리는 중
   const handleMouseMove = (e: any) => {
     if (!isDrawing) return;
+
     if (selectedBrush === "eraser") {
-      handleErase(e);
+      handleErase(e, false);
       return;
     }
 
@@ -93,16 +99,14 @@ const KonvaCanvas = () => {
     dispatch(updateLines(newLines));
   };
 
-  // 지우개
-  const handleErase = (e: any) => {
+  // 지우기
+  const handleErase = (e: any, shouldSaveHistory: boolean) => {
     const stage = stageRef.current;
     if (!stage) return;
 
-    // 현재 마우스 위치
     const erasedPosition = stage.getPointerPosition();
     if (!erasedPosition) return;
 
-    // 마우스가 지나간 위치 근처의 선을 찾아서 삭제
     const newLines = lines.filter(
       (line) =>
         !line.points.some(
@@ -112,11 +116,24 @@ const KonvaCanvas = () => {
         )
     );
 
-    dispatch(updateLines(newLines));
+    if (shouldSaveHistory) {
+      dispatch(
+        updateLinesWithHistory({
+          newLines,
+          beforeLines: prevLinesBeforeErase.current || [],
+        })
+      );
+      prevLinesBeforeErase.current = null;
+    } else {
+      dispatch(updateLines(newLines));
+    }
   };
 
   // 그리기 또는 지우기 종료
-  const handleMouseUp = () => {
+  const handleMouseUp = (e: any) => {
+    if (isDrawing && selectedBrush === "eraser") {
+      handleErase(e, true);
+    }
     setIsDrawing(false);
   };
 

--- a/mongeul/src/components/write-diary/organisms/KonvaCanvas.tsx
+++ b/mongeul/src/components/write-diary/organisms/KonvaCanvas.tsx
@@ -26,9 +26,9 @@ const KonvaCanvas = () => {
   useEffect(() => {
     if (stageRef.current) {
       setStageRef(stageRef.current);
-      console.log("✅ stageRef 설정됨:", stageRef.current);
+      console.log("stageRef 설정됨:", stageRef.current);
     } else {
-      console.warn("⚠️ stageRef가 아직 설정되지 않았습니다.");
+      console.warn("stageRef가 아직 설정되지 않았습니다.");
     }
   }, [stageRef.current]); // `stageRef.current` 변경될 때 실행
 

--- a/mongeul/src/components/write-diary/organisms/KonvaCanvas.tsx
+++ b/mongeul/src/components/write-diary/organisms/KonvaCanvas.tsx
@@ -139,30 +139,32 @@ const KonvaCanvas = () => {
 
   return (
     <Card padding="">
-      <div>
-        <Stage
-          width={500}
-          height={500}
-          ref={stageRef}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseUp}
-        >
-          <Layer>
-            {lines.map((line, i) => (
-              <Line
-                key={i}
-                points={line.points.flat()}
-                stroke={line.stroke}
-                strokeWidth={line.strokeWidth}
-                tension={0.5}
-                lineCap="round"
-                lineJoin="round"
-              />
-            ))}
-          </Layer>
-        </Stage>
+      <div className="w-full overflow-x-auto">
+        <div className="w-[768px] flex-shrink-0">
+          <Stage
+            width={768}
+            height={500}
+            ref={stageRef}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseUp}
+          >
+            <Layer>
+              {lines.map((line, i) => (
+                <Line
+                  key={i}
+                  points={line.points.flat()}
+                  stroke={line.stroke}
+                  strokeWidth={line.strokeWidth}
+                  tension={0.5}
+                  lineCap="round"
+                  lineJoin="round"
+                />
+              ))}
+            </Layer>
+          </Stage>
+        </div>
       </div>
     </Card>
   );

--- a/mongeul/src/components/write-diary/templates/PictureForm.tsx
+++ b/mongeul/src/components/write-diary/templates/PictureForm.tsx
@@ -5,7 +5,7 @@ import PictureToolCard from "../organisms/PictureToolCard";
 
 export default function PictureForm() {
   return (
-    <div className="max-w-[500px] h-full flex flex-col justiry-center items-center gap-4 m-2">
+    <div className="w-full h-full flex flex-col justiry-center items-center gap-4 m-2">
       <Canvas />
       <PictureToolCard />
     </div>

--- a/mongeul/src/lib/api/diary.ts
+++ b/mongeul/src/lib/api/diary.ts
@@ -11,9 +11,6 @@ export const fetchDiaries = async (
 
     const response = await apiClient(`/api/v1/diaries${query}`, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
-      },
     });
 
     console.log("일기 데이터:", response);
@@ -33,9 +30,6 @@ export const fetchMyDiary = async (
     const query = lockPassword ? `?lockPassword=${lockPassword}` : "";
     const response = await apiClient(`/api/v1/diaries/${diaryId}${query}`, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
-      },
     });
 
     console.log(`일기 (${diaryId}) 데이터:`, response);

--- a/mongeul/src/lib/api/write-diary.ts
+++ b/mongeul/src/lib/api/write-diary.ts
@@ -195,11 +195,32 @@ export async function fetchDiaryDraft(): Promise<DraftResponse> {
   });
 }
 
-// 임시 저장된 일기 생성
+// 임시 저장된 공유일기 조회
+export async function fetchSharedDiaryDraft(
+  groupId: number
+): Promise<DraftResponse> {
+  return apiClient(`/api/v1/groups/${groupId}/share-diaries/drafts`, {
+    method: "GET",
+  });
+}
+
+// 임시 저장 일기 생성
 export async function createDiaryDraft(
   data: DraftRequest
 ): Promise<DraftResponse> {
   return apiClient("/api/v1/diaries/drafts", {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// 임시 저장 공유일기 생성
+export async function createSharedDiaryDraft(
+  data: DraftRequest,
+  groupId: number
+): Promise<DraftResponse> {
+  return apiClient(`/api/v1/groups/${groupId}/share-diaries/drafts`, {
     method: "POST",
     body: JSON.stringify(data),
     headers: { "Content-Type": "application/json" },

--- a/mongeul/src/lib/api/write-diary.ts
+++ b/mongeul/src/lib/api/write-diary.ts
@@ -188,6 +188,16 @@ export async function verifyDiaryEntry(
   });
 }
 
+// 특정 날짜 공유 일기 존재 여부 확인
+export async function verifySharedDiaryEntry(
+  today: string,
+  groupId: number
+): Promise<IsDiaryResponse> {
+  return apiClient(`/api/v1/groups/${groupId}/find?today=${today}`, {
+    method: "GET",
+  });
+}
+
 // 임시 저장된 일기 조회
 export async function fetchDiaryDraft(): Promise<DraftResponse> {
   return apiClient("/api/v1/diaries/drafts", {

--- a/mongeul/src/lib/api/write-diary.ts
+++ b/mongeul/src/lib/api/write-diary.ts
@@ -43,6 +43,41 @@ export async function createDiaryEntry(
   return response;
 }
 
+// 공유일기 생성
+export async function createSharedDiaryEntry(
+  data: DiaryRequest,
+  groupId: number
+): Promise<DiaryResponse> {
+  const formData = new FormData();
+
+  console.log("공유일기작성 데이터", data);
+
+  formData.append("title", data.title);
+  formData.append("content", data.content);
+  formData.append("date", data.date);
+  formData.append("weather", data.weather ?? "");
+  formData.append("feeling", data.feeling ?? "");
+  formData.append("privateStatus", data.privateStatus);
+
+  if (data.picture) {
+    const blob = await (await fetch(data.picture)).blob();
+    formData.append("picture", blob, "picture.png");
+  }
+
+  // pictureLines 추가
+  if (data.pictureLines) {
+    formData.append("pictureLines", JSON.stringify(data.pictureLines));
+  }
+
+  // API 요청
+  const response = await apiClient(`/api/v1/groups/${groupId}/share-diaries`, {
+    method: "POST",
+    body: formData,
+  });
+
+  return response;
+}
+
 // 일기 수정
 export async function updateDiaryEntry(
   data: DiaryRequest,
@@ -72,11 +107,50 @@ export async function updateDiaryEntry(
   });
 }
 
+// 공유일기 수정
+export async function updateSharedDiaryEntry(
+  data: DiaryRequest,
+  groupId: number,
+  shareDiaryId: number
+): Promise<DiaryResponse> {
+  const formData = new FormData();
+
+  formData.append("title", data.title);
+  formData.append("content", data.content);
+  formData.append("date", data.date);
+  formData.append("weather", data.weather ?? "");
+  formData.append("feeling", data.feeling ?? "");
+  formData.append("privateStatus", data.privateStatus);
+
+  if (data.picture) {
+    const blob = await (await fetch(data.picture)).blob();
+    formData.append("picture", blob, "picture.png");
+  }
+
+  if (data.pictureLines) {
+    formData.append("pictureLines", JSON.stringify(data.pictureLines));
+  }
+
+  return apiClient(`/api/v1/groups/${groupId}/share-diaries/${shareDiaryId}`, {
+    method: "PUT",
+    body: formData,
+  });
+}
+
 // 일기 삭제
 export async function deleteDiaryEntry(
   diaryId: number
 ): Promise<{ success: boolean; message: string }> {
   return apiClient(`/api/v1/diaries/${diaryId}`, {
+    method: "DELETE",
+  });
+}
+
+// 공유일기 삭제
+export async function deleteSharedDiaryEntry(
+  shareDiaryId: number
+): Promise<{ success: boolean; message: string }> {
+  return apiClient(`/api/v1/share-diaries/${shareDiaryId}`, {
     method: "DELETE",
   });
 }
@@ -89,6 +163,20 @@ export async function fetchDiaryDates(
   return apiClient(`/api/v1/diaries/date?year=${year}&month=${month}`, {
     method: "GET",
   });
+}
+
+// 공유일기 작성된 날짜 조회
+export async function fetchSharedDiaryDates(
+  year: number,
+  month: number,
+  groupId: number
+): Promise<DiaryDatesResponse> {
+  return apiClient(
+    `/api/v1/groups/${groupId}/date?year=${year}&month=${month}`,
+    {
+      method: "GET",
+    }
+  );
 }
 
 // 특정 날짜 일기 존재 여부 확인
@@ -118,11 +206,20 @@ export async function createDiaryDraft(
   });
 }
 
-// 그림일기 라인 조회 (API 응답 구조 수정)
+// 그림일기 라인 조회
 export async function fetchPictureLines(
   diaryId: number
 ): Promise<PictureLineResponse> {
   return apiClient(`/api/v1/diaries/${diaryId}/picture-lines`, {
+    method: "GET",
+  });
+}
+
+// 공유그림일기 라인 조회
+export async function fetchSharedPictureLines(
+  shareDiaryId: number
+): Promise<PictureLineResponse> {
+  return apiClient(`/api/v1/share-diaries/${shareDiaryId}/picture-lines`, {
     method: "GET",
   });
 }

--- a/mongeul/src/store/pictureSlice.ts
+++ b/mongeul/src/store/pictureSlice.ts
@@ -61,6 +61,21 @@ const pictureSlice = createSlice({
     updateLines: (state, action: PayloadAction<PictureLine[]>) => {
       state.lines = action.payload;
     },
+    updateLinesWithHistory: (
+      state,
+      action: PayloadAction<{
+        newLines: PictureLine[];
+        beforeLines?: PictureLine[];
+      }>
+    ) => {
+      const { newLines, beforeLines } = action.payload;
+      const backup = beforeLines ?? [...state.lines]; // 지우기 전 상태가 있으면 사용, 없으면 현재 상태
+
+      pushWithLimit(state.history, backup, MAX_HISTORY_LENGTH);
+      state.lines = newLines;
+      state.redoStack = [];
+    },
+
     undo: (state) => {
       if (state.history.length > 0) {
         const lastState = state.history.pop();
@@ -90,6 +105,7 @@ export const {
   addLine,
   removeLine,
   updateLines,
+  updateLinesWithHistory,
   undo,
   redo,
   resetPicture,

--- a/mongeul/src/utils/convertLinesToImage.ts
+++ b/mongeul/src/utils/convertLinesToImage.ts
@@ -7,7 +7,7 @@ export async function convertLinesToImage(
   return new Promise((resolve) => {
     // 가상 Konva Stage 생성 (DOM 없이 JS에서만 존재)
     const stage = new Konva.Stage({
-      width: 500,
+      width: 768,
       height: 500,
       container: document.createElement("div"), // DOM에 추가하지 않고 메모리상에서만 사용
     });


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX188pfl4WzuQGzwa5UJPgjzl2UDwP1wrPOY%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://moontower.gitstream.cm/v2/badge/collaboration-page?magicLinkId=AdwcfRC)
# 📌 Pull Request

## 📋 변경 사항
- [ ] 설정
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 기타 (설명 필요)

## 🔗 관련 이슈
- #89 

## 📜 변경 사항 설명
- 캔버스 스크롤 적용
- 글작성 페이지 로직 네가지로 분리 (개인일기 작성/수정, 공유일기 작성/수정)
- 임시저장 로직 분리 (개인임시저장 수정/작성->삭제, 공유일기 수정/작성->삭제)
- 임시저장 및 공유일기 작성 목록 스켈레톤 UI 추가
- 공유일기 작성 가능 친구목록 컴포넌트 추가
- 지우개 스택 오류 수정
- 그림일기 히스토리 길이 제한 추가 (30개)

## 📸 스크린샷 (선택사항)
- UI 변경이 있거나 주요 기능이 추가되었다면 스크린샷을 첨부해주세요.
